### PR TITLE
Release staging/2.8

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -57,7 +57,7 @@ params:
 
   releaseInfo: # Note: See the new directory's /content/x.x.x./_index.md page to set release-related frontmatter variables. 
     latest: "2.7.x" # displays matching directory's sections on home page; if blank, all directories are displayed.
-    patch: "2.7.4" # Used for announcements and to generate download links
+    patch: "2.8.0" # Used for announcements and to generate download links
 
   ## Nav features 
   navLevel: true  #  displays level-2 directory items in the file tree.

--- a/themes/pach-emdash/layouts/partials/directory.html
+++ b/themes/pach-emdash/layouts/partials/directory.html
@@ -27,19 +27,16 @@
             {{ template "directory" (dict "dir" .Pages "current" $.current "parent" .Parent "section" $.section "level" "2") }}
         </div>
     {{ else }}
-      <div class="c-ml-2  ml-3 {{if (eq $.section.Title .CurrentSection.Title) }}{{else}}closed-folder{{end}}">
-        
-        <a class="xs thin" href="{{ .RelPermalink }}">{{ if eq $.current .RelPermalink }}👉{{else}} {{end}} {{if .Title}}{{.Title}}{{else}}{{ path.BaseName . | humanize }}{{end}}</a>
-        
-    </div>
+      {{ if and (not .Params.hidden) }}
+        <div class="c-ml-2  ml-3 {{if (eq $.section.Title .CurrentSection.Title) }}{{else}}closed-folder{{end}}">
+          
+          <a class="xs thin" href="{{ .RelPermalink }}">{{ if eq $.current .RelPermalink }}👉{{else}} {{end}} {{if .Title}}{{.Title}}{{else}}{{ path.BaseName . | humanize }}{{end}}</a>
+          
+      </div>
+      {{end}}
     {{ end }}
   {{ end }}
 
 {{ end }}
 
 </section>
-
-
-
-
-{{/*  todo: make logic to display pages with a new param: directory  */}}

--- a/themes/pach-emdash/layouts/shortcodes/include.html
+++ b/themes/pach-emdash/layouts/shortcodes/include.html
@@ -1,0 +1,6 @@
+{{ $currentPage := .Page }}
+{{ $contentPath := .Get 0 }}
+{{ $parentRelease := $currentPage.Param "release" }}
+
+{{ $p := site.GetPage (printf "%s/%s" $parentRelease $contentPath) }}
+{{ $p.RenderShortcodes }}


### PR DESCRIPTION
Release staging branch for 2.8. Currently contains net new content for:

- [Global Configs (Cluster)](https://deploy-preview-63--pach-docs.netlify.app/latest/set-up/global-config/)
- [Set Cluster Defaults via Console](https://deploy-preview-63--pach-docs.netlify.app/latest/learn/console-guide/set-cluster-defaults/)
- [Updated CLI Docs](https://deploy-preview-63--pach-docs.netlify.app/latest/run-commands/)
- [Unified Deployment](https://deploy-preview-63--pach-docs.netlify.app/latest/set-up/unified-deployment)
- [Console Steps in Pipeline Tutorials](https://deploy-preview-63--pach-docs.netlify.app/latest/build-dags/tutorials/)

Other Changes:

- [camelCase all PPS references](https://deploy-preview-63--pach-docs.netlify.app/latest/build-dags/pipeline-spec/)
- Security notices for MockIDP
- [tolerations](https://deploy-preview-63--pach-docs.netlify.app/latest/build-dags/pipeline-spec/tolerations/) has been documented (overdue; not specific to 2.8)

**Note to self**: the merge conflict is not real; close this branch when finished sharing deploy preview and push only the docs-content pr when ready. 